### PR TITLE
Return bill data when querying graphapi with only openstatesUrl

### DIFF
--- a/graphapi/legislative.py
+++ b/graphapi/legislative.py
@@ -343,30 +343,30 @@ class LegislativeQuery:
             # remove domain, start and end slashes
             path = urlparse(openstatesUrl).path.strip("/")
 
-            # parse openstatesUrl into components
+            # parse openstatesUrl into state abbr, session, and bill_id
             m = re.match(r"(?P<abbr>\w+)/bills/(?P<session>.+)/(?P<bill_id>.+)", path)
 
             if m:
-              jid = abbr_to_jid( m['abbr'] )
-              identifier = fix_bill_id( m['bill_id'] )
-              session = m['session']
+                jid = abbr_to_jid(m['abbr'])
+                identifier = fix_bill_id(m['bill_id'])
+                session = m['session']
 
-              # query Bill with components
-              # (this bit taken from def bill in views/bills.py)
-              bill = Bill.objects.select_related(
-                  "legislative_session",
-                  "legislative_session__jurisdiction",
-                  "from_organization",
-              ).get(
-                  legislative_session__jurisdiction_id=jid,
-                  legislative_session__identifier=session,
-                  identifier=identifier,
-              )
+                # query Bill with components
+                # (this bit taken from def bill in views/bills.py)
+                bill = Bill.objects.select_related(
+                    "legislative_session",
+                    "legislative_session__jurisdiction",
+                    "from_organization",
+                ).get(
+                    legislative_session__jurisdiction_id=jid,
+                    legislative_session__identifier=session,
+                    identifier=identifier,
+                )
             else:
-              raise ValueError("Unable to parse openstatesUrl. openstatesUrl may be malformed.")
+                raise ValueError("Unable to parse openstatesUrl. openstatesUrl may be malformed.")
 
         if not bill:
-            raise ValueError("must either pass 'id', 'openstatesUrl', or 'jurisdiction', 'session', "
-                             "and 'identifier' together")
+            raise ValueError("must either pass 'id', 'openstatesUrl', or 'jurisdiction', "
+                             "'session', and 'identifier' together")
 
         return bill

--- a/graphapi/tests/test_legislative.py
+++ b/graphapi/tests/test_legislative.py
@@ -134,6 +134,18 @@ def test_bill_openstates_url(django_assert_num_queries):
 
 
 @pytest.mark.django_db
+def test_bill_by_openstates_url(django_assert_num_queries):
+    with django_assert_num_queries(1):
+        result = schema.execute(''' {
+            bill(openstatesUrl:"https://openstates.org/ak/bills/2018/HB1") {
+            id
+            }
+        }''')
+        assert result.errors is None
+        assert result.data['bill']['id'] == 'ocd-bill/1'
+
+
+@pytest.mark.django_db
 def test_bill_by_jurisdiction_name_session_identifier(django_assert_num_queries):
     with django_assert_num_queries(1):
         result = schema.execute(''' {


### PR DESCRIPTION
Per [this issue](/openstates/openstates.org/issues/207) I would like to track bill status changes from the GraphQL API when just knowing the OpenStates URL. I've updated graphapi/legislative.py to accept openstatesUrl alone as a valid query to return the bill object.