### PR TITLE
Allow "." in bill-id portion of url to fix #179

### DIFF
--- a/public/urls.py
+++ b/public/urls.py
@@ -45,7 +45,7 @@ urlpatterns = [
         name="bills_feed",
     ),
     re_path(
-        r"^(?P<state>{})/bills/(?P<session>[-\w ]+)/(?P<bill_id>[-\w ]+)/$".format(
+        r"^(?P<state>{})/bills/(?P<session>[-\w ]+)/(?P<bill_id>[-\w\. ]+)/$".format(
             state_abbr_pattern
         ),
         bill,


### PR DESCRIPTION
Utah bill pages couldn't be shown because they have a "." in the bill id.