### PR TITLE
Update search input appearance

### DIFF
--- a/public/static/public/styles/components/_inputs.scss
+++ b/public/static/public/styles/components/_inputs.scss
@@ -19,7 +19,7 @@ textarea,
 select {
     border-width: 1px;
     transition: border ease-in 200ms;
-    
+
     &:focus,
     &:active {
         border-color: $color-primary;
@@ -99,6 +99,14 @@ input[type='radio'] {
     font-weight: normal;
     margin-top: 0.1rem;
     margin-bottom: 0.1rem;
+}
+
+
+// Search
+[type='search'] {
+    -moz-appearance: none;
+    -webkit-appearance: none;
+    appearance: none;
 }
 
 


### PR DESCRIPTION
This PR adds some styling that removes the default appearance of search inputs on mobile/iOS Safari (see "before" screenshot below).

I had trouble getting the database imported locally to verify this change, but it _should_ be fairly benign and consequence-free.

Thanks for your consideration of this change!

![IMG_AA76F2A1436C-1](https://user-images.githubusercontent.com/73866/74087666-8b231400-4a5c-11ea-98f0-ae5b4f233a10.jpeg)
