### PR TITLE
Render abstract on bill detail page

### DIFF
--- a/templates/public/views/bill.html
+++ b/templates/public/views/bill.html
@@ -83,6 +83,16 @@
             {% endif %}
 
 
+            {% if bill.abstracts %}
+            <div class="mb2">
+                <h3 class="heading--xsmall">Abstract</h3>
+                {% for abstract in bill.abstracts.all %}
+                    <p style="white-space: pre-line">{{ abstract.abstract | safe }}</p>
+                {% endfor %}
+            </div>
+            {% endif %}
+
+
             <h3 class="heading--xsmall">Bill Sponsors ({{ sponsorships|length }})</h3>
             
             <div class="grid-container full">


### PR DESCRIPTION
The bill scrapers for several states save abstracts, but this information is not displayed anywhere on the website. This change will show the abstract below the bill subjects (if available) in the bill overview card.

An example of what the bill card would look like after this change:

![AB2016 2020 sample](https://user-images.githubusercontent.com/5530739/74639210-5715b600-5122-11ea-9485-83ec4377f78b.png)

Feedback is welcome on stylistic changes (either to the code or to the formatting of the abstract on the page).
