### PR TITLE
Show newest votes on legislator page

### DIFF
--- a/public/views/legislators.py
+++ b/public/views/legislators.py
@@ -144,9 +144,11 @@ def person(request, person_id):
         .order_by("-created_at", "id")[:SPONSORED_BILLS_TO_SHOW]
     )
 
-    votes = person.votes.all().select_related("vote_event", "vote_event__bill")[
-        :RECENT_VOTES_TO_SHOW
-    ]
+    votes = (
+        person.votes.all()
+        .select_related("vote_event", "vote_event__bill")
+        .order_by("-vote_event__start__date")[:RECENT_VOTES_TO_SHOW]
+    )
     person.vote_events = []
     for vote in votes:
         vote_event = vote.vote_event


### PR DESCRIPTION
The "recent votes" section used default sorting, so it didn't guarantee that it would actually show the legislator's most recent votes.