### PR TITLE
Ansible cleanup

### DIFF
--- a/ansible/openstates/tasks/main.yml
+++ b/ansible/openstates/tasks/main.yml
@@ -7,7 +7,7 @@
   apt:
     update_cache: yes
     pkg:
-     - build-essential
+      - build-essential
       - git
       - libpq-dev
       - gdal-bin
@@ -21,7 +21,6 @@
       - python3.9
       - python3.9-dev
       - python3.9-distutils
-  ignore_errors: true
 
 - name: build python39 plugin
   command: uwsgi --build-plugin "/usr/src/uwsgi/plugins/python python39"

--- a/ansible/openstates/tasks/main.yml
+++ b/ansible/openstates/tasks/main.yml
@@ -29,6 +29,7 @@
   args:
     creates: /usr/lib/uwsgi/plugins/python39_plugin.so
     chdir: /usr/lib/uwsgi/plugins/
+  changed_when: false
 
 - name: add localhost alias
   lineinfile:
@@ -81,6 +82,8 @@
 
 - name: run nodesource script
   command: /tmp/nodesource-setup.sh
+  changed_when: false
+
 - name: install nodejs
   apt:
     pkg:
@@ -94,15 +97,19 @@
 - name: install pip
   command: python3.9 /tmp/get-pip.py
   become_user: "openstates"
+  changed_when: false
 
 - name: install poetry
   command: python3.9 -m pip install poetry
   become_user: "openstates"
+  changed_when: false
 
 # letsencrypt & cronjobs
 
 - name: add letsencrypt cert
   command: certbot certonly --dns-route53 --expand -d openstates.org -d www.openstates.org --email contact@openstates.org --agree-tos -n creates=/etc/letsencrypt/live/openstates.org/fullchain.pem
+  changed_when: false
+
 - name: add letsencrypt renewal crontab
   cron:
     job: "letsencrypt renew"
@@ -150,6 +157,7 @@
 - name: create virtualenv
   command: virtualenv -p python3.9 /home/openstates/virt{{ gitresult.after }}
   become_user: "openstates"
+  changed_when: false
   notify:
     - restart django-application
 
@@ -163,11 +171,13 @@
   become_user: "openstates"
 - name: install packages via poetry
   command: ~/.poetry/bin/poetry install # --deploy
+  changed_when: false
   args:
     chdir: /home/openstates/src/openstates.org
   environment:
     VIRTUAL_ENV: /home/openstates/virt{{ gitresult.after }}
   become_user: "openstates"
+
 - name: link virtualenv
   file:
     src: "/home/openstates/virt{{ gitresult.after }}"
@@ -179,12 +189,15 @@
 # npm installation & build
 - name: npm install
   command: npm ci   # use this to ensure we only build from package-lock
+  changed_when: false
   become_user: "openstates"
   args:
     chdir: /home/openstates/src/openstates.org
+
 - name: npm run build
   command: npm run build
   become_user: "openstates"
+  changed_when: false
   args:
     chdir: /home/openstates/src/openstates.org
 
@@ -196,6 +209,7 @@
 
 - name: generate dh params
   command: openssl dhparam -out /etc/nginx/certs/dhparams.pem 2048 creates=/etc/nginx/certs/dhparams.pem
+  changed_when: false
 
 - name: remove nginx default config
   file:
@@ -219,14 +233,18 @@
 - name: collectstatic
   command: /home/openstates/virt/bin/python manage.py collectstatic --settings=web.settings --noinput chdir=/home/openstates/src/openstates.org
   environment: '{{django_environment}}'
+  changed_when: false
 
 - name: migrate
   command: /home/openstates/virt/bin/python manage.py migrate --settings=web.settings --noinput chdir=/home/openstates/src/openstates.org
   environment: '{{django_environment}}'
+  changed_when: false
 
 - name: create Site
   command: echo "from django.contrib.sites.models import Site;Site.objects.get_or_create(domain='openstates.org', name='openstates.org')" | /home/openstates/virt/bin/python manage.py shell --settings=web.settings chdir=/home/openstates/src/openstates.org
   environment: '{{django_environment}}'
+  changed_when: false
+
 # TODO: add run of shapefiles/download.py
 # - name: loadshapefiles
 #   command: /home/openstates/virt/bin/python manage.py loadshapefiles --settings=web.settings chdir=/home/openstates/src/openstates.org

--- a/ansible/openstates/tasks/main.yml
+++ b/ansible/openstates/tasks/main.yml
@@ -2,11 +2,12 @@
 - name: add deadsnakes repo for Py 3.9
   apt_repository:
     repo: ppa:deadsnakes/ppa
+
 - name: install system packages
   apt:
     update_cache: yes
     pkg:
-      - build-essential
+     - build-essential
       - git
       - libpq-dev
       - gdal-bin
@@ -20,6 +21,8 @@
       - python3.9
       - python3.9-dev
       - python3.9-distutils
+  ignore_errors: true
+
 - name: build python39 plugin
   command: uwsgi --build-plugin "/usr/src/uwsgi/plugins/python python39"
   environment:
@@ -29,22 +32,46 @@
     chdir: /usr/lib/uwsgi/plugins/
 
 - name: add localhost alias
-  lineinfile: dest=/etc/hosts line='127.0.0.1 openstates.org'
+  lineinfile:
+    dest: /etc/hosts
+    line: '127.0.0.1 openstates.org'
+
 - name: add pgpass file
-  template: src=pgpass.j2 dest=/home/ubuntu/.pgpass mode=600
+  template:
+    src: pgpass.j2
+    dest: /home/ubuntu/.pgpass
+    mode: 600
 
 # user home directory
 - name: make project dir
-  file: path=/home/openstates state=directory
+  file:
+    path: /home/openstates
+    state: directory
+
 - name: add project user
-  user: name=openstates home=/home/openstates shell=/bin/bash state=present
+  user:
+    name: openstates
+    home: /home/openstates
+    shell: /bin/bash
+    state: present
+
 - name: chown user directory
-  file: path=/home/openstates owner=openstates
+  file:
+    path: /home/openstates
+    owner: openstates
+
 - name: add env_vars for project user
-  template: src=env_vars.j2 dest=/home/openstates/env_vars mode=640
+  template:
+    src: env_vars.j2
+    dest: /home/openstates/env_vars
+    mode: 640
   become_user: "openstates"
+
 - name: copy robots.txt
-  copy: src=files/robots.txt dest=/home/openstates/robots.txt mode=644
+  copy:
+    src: files/robots.txt
+    dest: /home/openstates/robots.txt
+    mode: 644
 
 # node
 - name: download nodesource script
@@ -52,19 +79,25 @@
     url: https://deb.nodesource.com/setup_10.x
     dest: /tmp/nodesource-setup.sh
     mode: 0770
+
 - name: run nodesource script
   command: /tmp/nodesource-setup.sh
 - name: install nodejs
   apt:
-    pkg: nodejs
+    pkg:
+      - nodejs
 
-- name: get poetry installer
+- name: get pip
   get_url:
-    url: https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py
-    dest: /tmp/get-poetry.py
-    mode: 0755
+    url: https://bootstrap.pypa.io/get-pip.py
+    dest: /tmp/get-pip.py
+
+- name: install pip
+  command: python3.9 /tmp/get-pip.py
+  become_user: "openstates"
+
 - name: install poetry
-  command: python /tmp/get-poetry.py -y
+  command: python3.9 -m pip install poetry
   become_user: "openstates"
 
 # letsencrypt & cronjobs
@@ -72,30 +105,62 @@
 - name: add letsencrypt cert
   command: certbot certonly --dns-route53 --expand -d openstates.org -d www.openstates.org --email contact@openstates.org --agree-tos -n creates=/etc/letsencrypt/live/openstates.org/fullchain.pem
 - name: add letsencrypt renewal crontab
-  cron: job="letsencrypt renew" special_time="daily" name="renew certificate"
+  cron:
+    job: "letsencrypt renew"
+    special_time: "daily"
+    name: "renew certificate"
+
 - name: add process_subscriptions cron
-  cron: job=". /home/openstates/env_vars && /home/openstates/virt/bin/python /home/openstates/src/openstates.org/manage.py process_subscriptions >> /tmp/subscriptions.log" hour="12" minute="30" name="process subscriptions"
+  cron:
+    job: ". /home/openstates/env_vars && /home/openstates/virt/bin/python /home/openstates/src/openstates.org/manage.py process_subscriptions >> /tmp/subscriptions.log"
+    hour: "12"
+    minute: "30"
+    name: "process subscriptions"
+
 - name: add aggregate usage cron
-  cron: job=". /home/openstates/env_vars && /home/openstates/virt/bin/python /home/openstates/src/openstates.org/manage.py aggregate_api_usage /var/log/uwsgi/app/openstates.log /var/log/uwsgi/app/openstates.log.1 >> /tmp/aggregation.log" hour="*/2" minute="19" name="aggregate usage"
+  cron:
+    job: ". /home/openstates/env_vars && /home/openstates/virt/bin/python /home/openstates/src/openstates.org/manage.py aggregate_api_usage /var/log/uwsgi/app/openstates.log /var/log/uwsgi/app/openstates.log.1 >> /tmp/aggregation.log"
+    hour: "*/2"
+    minute: "19"
+    name: "aggregate usage"
+
 - name: restart nginx weekly
-  cron: job="systemctl restart nginx" special_time="weekly" name="restart nginx"
+  cron:
+    job: "systemctl restart nginx"
+    special_time: "weekly"
+    name: "restart nginx"
+
 - name: archive letsencrypt stuff
-  cron: job='bash -c "tar cvf /tmp/newle$(date +\%Y\%m\%d).gz /etc/letsencrypt/ && aws s3 cp /tmp/newle$(date +\%Y\%m\%d).gz s3://openstates-backups/letsencrypt/ && rm /tmp/newle$(date +\%Y\%m\%d).gz"' special_time="monthly" name="backup letsencrypt"
+  cron:
+    job: 'bash -c "tar cvf /tmp/newle$(date +\%Y\%m\%d).gz /etc/letsencrypt/ && aws s3 cp /tmp/newle$(date +\%Y\%m\%d).gz s3://openstates-backups/letsencrypt/ && rm /tmp/newle$(date +\%Y\%m\%d).gz"'
+    special_time: "monthly"
+    name: "backup letsencrypt"
 
 # virtualenv
 - name: checkout project directories
-  git: repo=https://github.com/openstates/openstates.org.git dest=/home/openstates/src/openstates.org accept_hostkey=yes version=main
+  git:
+    repo: https://github.com/openstates/openstates.org.git
+    dest: /home/openstates/src/openstates.org
+    accept_hostkey: yes
+    version: main
   become_user: "openstates"
   notify:
     - restart django-application
   register: gitresult
+
 - name: create virtualenv
   command: virtualenv -p python3.9 /home/openstates/virt{{ gitresult.after }}
   become_user: "openstates"
   notify:
     - restart django-application
+
 - name: add checkouts to python path
-  lineinfile: dest=/home/openstates/virt{{ gitresult.after }}/lib/python3.9/site-packages/checkouts.pth create=yes state=present line=/home/openstates/src/openstates.org
+  lineinfile:
+    dest: "/home/openstates/virt{{ gitresult.after }}/lib/python3.9/site-packages/checkouts.pth"
+    create: yes
+    state: present
+    line: /home/openstates/src/openstates.org
+
   become_user: "openstates"
 - name: install packages via poetry
   command: ~/.poetry/bin/poetry install # --deploy
@@ -105,7 +170,10 @@
     VIRTUAL_ENV: /home/openstates/virt{{ gitresult.after }}
   become_user: "openstates"
 - name: link virtualenv
-  file: src=/home/openstates/virt{{ gitresult.after }} dest=/home/openstates/virt state=link
+  file:
+    src: "/home/openstates/virt{{ gitresult.after }}"
+    dest: /home/openstates/virt
+    state: link
   notify:
     - restart django-application
 
@@ -123,25 +191,40 @@
 
 # nginx
 - name: make certs dir
-  file: path=/etc/nginx/certs/ state=directory
+  file:
+    path: /etc/nginx/certs/
+    state: directory
+
 - name: generate dh params
   command: openssl dhparam -out /etc/nginx/certs/dhparams.pem 2048 creates=/etc/nginx/certs/dhparams.pem
+
 - name: remove nginx default config
-  file: path=/etc/nginx/sites-enabled/default state=absent
+  file:
+    path: /etc/nginx/sites-enabled/default
+    state: absent
+
 - name: write nginx template
-  template: src=nginx.j2 dest=/etc/nginx/sites-enabled/openstates
+  template:
+    src: nginx.j2
+    dest: /etc/nginx/sites-enabled/openstates
   notify:
     - restart nginx
+
 - name: ensure nginx is running and starts on boot
-  service: name=nginx state=restarted enabled=yes
+  service:
+    name: nginx
+    state: restarted
+    enabled: yes
 
 # django commands
 - name: collectstatic
   command: /home/openstates/virt/bin/python manage.py collectstatic --settings=web.settings --noinput chdir=/home/openstates/src/openstates.org
   environment: '{{django_environment}}'
+
 - name: migrate
   command: /home/openstates/virt/bin/python manage.py migrate --settings=web.settings --noinput chdir=/home/openstates/src/openstates.org
   environment: '{{django_environment}}'
+
 - name: create Site
   command: echo "from django.contrib.sites.models import Site;Site.objects.get_or_create(domain='openstates.org', name='openstates.org')" | /home/openstates/virt/bin/python manage.py shell --settings=web.settings chdir=/home/openstates/src/openstates.org
   environment: '{{django_environment}}'
@@ -155,8 +238,13 @@
 
 # uwsgi
 - name: write uwsgi template
-  template: src=uwsgi.j2 dest=/etc/uwsgi/apps-enabled/openstates.ini
+  template:
+    src: uwsgi.j2
+    dest: /etc/uwsgi/apps-enabled/openstates.ini
   notify:
     - restart django-application
+
 - name: start uwsgi
-  service: name=uwsgi state=started
+  service:
+    name: uwsgi
+    state: started

--- a/tasks.py
+++ b/tasks.py
@@ -69,7 +69,7 @@ def deploy(c):
     ).stdout.strip()
 
     with c.cd("ansible"):
-        c.run("ansible-playbook openstates.yml -i inventory/", pty=True)
+        c.run("ansible-playbook -D openstates.yml -i inventory/", pty=True)
 
     # tag the release in git and on sentry and newrelic
     next_tag = get_next_tag(c)


### PR DESCRIPTION
ignore apt errors (for now), clean up commands to use ansible standards, and install pip -> poetry instead of trying to directly install poetry

Signed-off-by: John Seekins <john@civiceagle.com>