### PR TITLE
No compressed backups

### DIFF
--- a/docker/cron/backup.sh
+++ b/docker/cron/backup.sh
@@ -3,24 +3,25 @@ set -e
 
 # backup everything to private archive
 echo "Extracting full backup..."
-pg_dump -Fc openstatesorg | gzip > openstatesorg.pgdump.gz
+pg_dump -Fc openstatesorg > openstatesorg.pgdump
 echo "Shipping full backup to s3"
-aws s3 cp openstatesorg.pgdump.gz "s3://openstates-backups/full-backup/$(date +%Y-%m-%d)-openstatesorg.pgdump.gz"
-rm -f openstatesorg.pgdump.gz
+aws s3 cp openstatesorg.pgdump "s3://openstates-backups/full-backup/$(date +%Y-%m-%d)-openstatesorg.pgdump"
+rm -f openstatesorg.pgdump
 
 
 # layered approach for public
 echo "Executing public schema-only backup..."
-pg_dump -Fc openstatesorg --schema-only | gzip > schema.pgdump.gz
+pg_dump -Fc openstatesorg --schema-only > schema.pgdump
+aws s3 cp --acl public-read schema.pgdump "s3://data.openstates.org/postgres/schema/$(date +%Y-%m)-schema.pgdump"
+
 echo "Executing public data backup..."
 pg_dump -Fc openstatesorg --data-only \
   --table=opencivicdata* \
   --table=django_migrations \
   --table=django_content_type \
   --table=django_site \
-  | gzip > public.pgdump.gz
+  > public.pgdump
 
 echo "Uploading public backups to s3..."
-aws s3 cp --acl public-read schema.pgdump.gz "s3://data.openstates.org/postgres/schema/$(date +%Y-%m)-schema.pgdump.gz"
-aws s3 cp --acl public-read public.pgdump.gz "s3://data.openstates.org/postgres/daily/$(date +%Y-%m-%d)-public.pgdump.gz"
-aws s3 cp --acl public-read public.pgdump.gz "s3://data.openstates.org/postgres/monthly/$(date +%Y-%m)-public.pgdump.gz"
+aws s3 cp --acl public-read public.pgdump "s3://data.openstates.org/postgres/daily/$(date +%Y-%m-%d)-public.pgdump"
+aws s3 cp --acl public-read public.pgdump "s3://data.openstates.org/postgres/monthly/$(date +%Y-%m)-public.pgdump"

--- a/docker/cron/backup.sh
+++ b/docker/cron/backup.sh
@@ -1,6 +1,16 @@
 #!/bin/sh
 set -e
 
+#####
+# Quick note:
+# pg_dump -Fc is single-threaded, but *is* compressed
+# Improving storage and performance could be achieved with
+# a combination of '-j' (parallel table export)
+# and piping to gzip or zstd
+# but that complicates the process for restoration
+# so we should only do it once we need to
+####
+
 # backup everything to private archive
 echo "Extracting full backup..."
 pg_dump -Fc openstatesorg > openstatesorg.pgdump

--- a/docker/cron/backup.sh
+++ b/docker/cron/backup.sh
@@ -5,14 +5,14 @@ set -e
 echo "Extracting full backup..."
 pg_dump -Fc openstatesorg > openstatesorg.pgdump
 echo "Shipping full backup to s3"
-aws s3 cp openstatesorg.pgdump "s3://openstates-backups/full-backup/$(date +%Y-%m-%d)-openstatesorg.pgdump"
+aws s3 cp openstatesorg.pgdump "s3://openstates-backups/full-backup/$(date +%Y-%m-%d)-openstatesorg.pgdump" > /dev/null
 rm -f openstatesorg.pgdump
 
 
 # layered approach for public
 echo "Executing public schema-only backup..."
 pg_dump -Fc openstatesorg --schema-only > schema.pgdump
-aws s3 cp --acl public-read schema.pgdump "s3://data.openstates.org/postgres/schema/$(date +%Y-%m)-schema.pgdump"
+aws s3 cp --acl public-read schema.pgdump "s3://data.openstates.org/postgres/schema/$(date +%Y-%m)-schema.pgdump" > /dev/null
 
 echo "Executing public data backup..."
 pg_dump -Fc openstatesorg --data-only \
@@ -23,5 +23,5 @@ pg_dump -Fc openstatesorg --data-only \
   > public.pgdump
 
 echo "Uploading public backups to s3..."
-aws s3 cp --acl public-read public.pgdump "s3://data.openstates.org/postgres/daily/$(date +%Y-%m-%d)-public.pgdump"
-aws s3 cp --acl public-read public.pgdump "s3://data.openstates.org/postgres/monthly/$(date +%Y-%m)-public.pgdump"
+aws s3 cp --acl public-read public.pgdump "s3://data.openstates.org/postgres/daily/$(date +%Y-%m-%d)-public.pgdump" > /dev/null
+aws s3 cp --acl public-read public.pgdump "s3://data.openstates.org/postgres/monthly/$(date +%Y-%m)-public.pgdump" > /dev/null


### PR DESCRIPTION
Compression was already happening from postgres itself. We might revisit this later with more aggressive compression and a `-j` switch in `pg_dump`, but simply removing the temp files during the run makes enough difference to let backup jobs  complete.