### PR TITLE
Canonical Redirects & Updated Warning Copy

### DIFF
--- a/public/templatetags/custom_tags.py
+++ b/public/templatetags/custom_tags.py
@@ -133,6 +133,11 @@ def dash_check(session):
 
 
 @register.filter()
+def format_uuid(person_id):
+    return person_id.split("/")[1]
+
+
+@register.filter()
 def format_address(address):
     return mark_safe(address.replace(";", "<br>"))
 

--- a/public/templatetags/custom_tags.py
+++ b/public/templatetags/custom_tags.py
@@ -125,6 +125,14 @@ def titlecase_caps(title):
 
 
 @register.filter()
+def dash_check(session):
+    if "-" in session:
+        return session.replace("-", "_")
+    else:
+        return session
+
+
+@register.filter()
 def format_address(address):
     return mark_safe(address.replace(";", "<br>"))
 

--- a/templates/account/profile.html
+++ b/templates/account/profile.html
@@ -17,7 +17,7 @@
   {% endif %}
 </p>
 <div style="padding: .75rem 1.25rem; border: 1px solid #ffeeba; background-color: #fff3cd; margin-bottom: 1rem;">
-    On June 30, we’re launching a new, free bill research and tracking application!
+    On June 30, we’re launching a new, free bill research and tracking application!<br>
     Heads-up, that will mean about an hour of downtime at approximately 9 AM CDT, during which openstates.org may be
     unavailable.<br>
     Once launched, this page will redirect to that new application at
@@ -25,8 +25,8 @@
     You are invited to try out our new tools, and also you will still be able to access
     your existing OpenStates.org account.
     <a href="https://blog.openstates.org/2023-june-changes/">
-        Please read more about these upcoming changes here
-    </a>.
+        Please read more about these upcoming changes here.
+    </a>
 </div>
 <hr>
 

--- a/templates/account/profile.html
+++ b/templates/account/profile.html
@@ -18,6 +18,8 @@
 </p>
 <div style="padding: .75rem 1.25rem; border: 1px solid #ffeeba; background-color: #fff3cd; margin-bottom: 1rem;">
     On June 30, we’re launching a new, free bill research and tracking application!
+    Heads-up, that will mean about an hour of downtime at approximately 9 AM CDT, during which openstates.org may be
+    unavailable.<br>
     Once launched, this page will redirect to that new application at
     <a href="https://pluralpolicy.com">pluralpolicy.com</a>.
     You are invited to try out our new tools, and also you will still be able to access

--- a/templates/public/components/base.html
+++ b/templates/public/components/base.html
@@ -22,7 +22,8 @@
         <meta property="og:url" content="{{ request.build_absolute_uri }}">
         <meta property="og:title" content="{% block og_title %}Open States{% endblock %}">
         <meta property="og:image" content="{% block og_image %}https://{{ request.get_host }}{% static "images/openstates_icon_transparent.png" %}{% endblock %}">
-        
+        {% block link %}{% endblock %}
+
         <!-- Favicon -->
         <link rel="apple-touch-icon" sizes="180x180" href="{% static 'images/favicon/apple-touch-icon.png?v=20190106' %}">
         <link rel="icon" type="image/png" sizes="32x32" href="{% static 'images/favicon/favicon-32x32.png?v=20190106' %}">

--- a/templates/public/views/bill.html
+++ b/templates/public/views/bill.html
@@ -6,7 +6,7 @@
 {% block og_title %}{{ bill.identifier }} - {{ state|state_name }} {{ bill.from_organization.name }} ({{bill.legislative_session.identifier }}) - Open States{% endblock %}
 {% block description %}Details on {{ state|state_name }} {{ bill.identifier}} ({{ bill.legislative_session }}) - {{ bill.title|titlecase_caps }}{% endblock %}
 {% block link %}
-    <link rel="canonical" href="https://pluralpolicy.com/app/legislative-tracking/bill/details/state-{{ state }}-{{bill.legislative_session.identifier }}-{{ bill.identifier }}" />
+    <link rel="canonical" href="https://pluralpolicy.com/app/legislative-tracking/bill/details/state-{{ state }}-{{bill.legislative_session.identifier|dash_check }}-{{ bill.identifier|cut:" "|lower }}" />
 {% endblock %}
 
 {% block scripts %}

--- a/templates/public/views/bill.html
+++ b/templates/public/views/bill.html
@@ -5,10 +5,12 @@
 {% block title %}{{ bill.identifier }} - {{ state|state_name }} {{ bill.from_organization.name }} ({{bill.legislative_session.identifier }}) - Open States{% endblock %}
 {% block og_title %}{{ bill.identifier }} - {{ state|state_name }} {{ bill.from_organization.name }} ({{bill.legislative_session.identifier }}) - Open States{% endblock %}
 {% block description %}Details on {{ state|state_name }} {{ bill.identifier}} ({{ bill.legislative_session }}) - {{ bill.title|titlecase_caps }}{% endblock %}
+{% block link %}
+    <link rel="canonical" href="https://pluralpolicy.com/app/legislative-tracking/bill/details/state-{{ state }}-{{bill.legislative_session.identifier }}-{{ bill.identifier }}" />
+{% endblock %}
 
 {% block scripts %}
   <script src="{% static "bundles/common_components.js" %}"></script>
-    <link rel="canonical" href="https://pluralpolicy.com/app/legislative-tracking/bill/details/state-{{ state }}-{{bill.legislative_session.identifier }}-{{ bill.identifier }}" />
 {% endblock %}
 
 {% block content %}

--- a/templates/public/views/bill.html
+++ b/templates/public/views/bill.html
@@ -8,12 +8,13 @@
 
 {% block scripts %}
   <script src="{% static "bundles/common_components.js" %}"></script>
+    <link rel="canonical" href="https://pluralpolicy.com/app/legislative-tracking/bill/details/state-{{ state }}-{{bill.legislative_session.identifier }}-{{ bill.identifier }}" />
 {% endblock %}
 
 {% block content %}
 <section class="section">
     <div class="overview">
-        
+
         <div class="overview__header">
             <div style="width: 100%;">
                 <div class="align-justify meter-container">
@@ -70,7 +71,7 @@
                 </div>
             </div>
         </div>
-        
+
         <div class="overview__section">
             {% if bill.subject %}
             <div class="mb2">
@@ -94,7 +95,7 @@
 
 
             <h3 class="heading--xsmall">Bill Sponsors ({{ sponsorships|length }})</h3>
-            
+
             <div class="grid-container full">
                 <div class="grid-x grid-margin-x medium-up-2 large-up-3">
                     {% for sponsor in sponsorships|dictsortreversed:"primary" %}
@@ -168,7 +169,7 @@
     </div>
 </section>
 
-<section>    
+<section>
     <h2 class="heading--medium">Actions</h2>
     <hr>
     <div class="timeline">

--- a/templates/public/views/find_your_legislator.html
+++ b/templates/public/views/find_your_legislator.html
@@ -5,9 +5,9 @@
 {% block title %}Find Your State Legislators - Open States{% endblock %}
 {% block og_title %}Find Your State Legislators - Open States{% endblock %}
 {% block description %}Find out who represents you in your state legislature with Open States.{% endblock %}
+{% block link %}<link rel="canonical" href="https://pluralpolicy.com/find-your-legislator" />{% endblock %}
 {% block scripts %}
     <script src="{% static "bundles/fyl.js" %}"></script>
-    <link rel="canonical" href="https://pluralpolicy.com/find-your-legislator" />
 {% endblock %}
 
 {% block content %}

--- a/templates/public/views/find_your_legislator.html
+++ b/templates/public/views/find_your_legislator.html
@@ -15,6 +15,8 @@
     <hr>
     <div style="padding: .75rem 1.25rem; border: 1px solid #ffeeba; background-color: #fff3cd; margin-bottom: 1rem;">
         On June 30, we’re launching a new, free bill research and tracking application!
+        Heads-up, that will mean about an hour of downtime at approximately 9 AM CDT, during which openstates.org may be
+        unavailable.<br>
         Once launched, this page will redirect to that new application at
         <a href="https://pluralpolicy.com">pluralpolicy.com</a>.
         You are invited to try out our new tools, and also you will still be able to access

--- a/templates/public/views/find_your_legislator.html
+++ b/templates/public/views/find_your_legislator.html
@@ -7,6 +7,7 @@
 {% block description %}Find out who represents you in your state legislature with Open States.{% endblock %}
 {% block scripts %}
     <script src="{% static "bundles/fyl.js" %}"></script>
+    <link rel="canonical" href="https://pluralpolicy.com/find-your-legislator" />
 {% endblock %}
 
 {% block content %}
@@ -14,7 +15,7 @@
     <h2 class="mb2 heading--medium">Look your legislators up by address or use your current location.</h2>
     <hr>
     <div style="padding: .75rem 1.25rem; border: 1px solid #ffeeba; background-color: #fff3cd; margin-bottom: 1rem;">
-        On June 30, we’re launching a new, free bill research and tracking application!
+        On June 30, we’re launching a new, free bill research and tracking application!<br>
         Heads-up, that will mean about an hour of downtime at approximately 9 AM CDT, during which openstates.org may be
         unavailable.<br>
         Once launched, this page will redirect to that new application at
@@ -22,8 +23,8 @@
         You are invited to try out our new tools, and also you will still be able to access
         your existing OpenStates.org account.
         <a href="https://blog.openstates.org/2023-june-changes/">
-            Please read more about these upcoming changes here
-        </a>.
+            Please read more about these upcoming changes here.
+        </a>
     </div>
     <p>
       Data here now has been updated to reflect the 2020-2022 redistricting process. Results here now

--- a/templates/public/views/home.html
+++ b/templates/public/views/home.html
@@ -12,6 +12,8 @@
     <div class="homepage-hero">
         <div style="padding: .75rem 1.25rem; border: 1px solid #ffeeba; background-color: #fff3cd; margin-bottom: 1rem;">
             On June 30, we’re launching a new, free bill research and tracking application!
+            Heads-up, that will mean about an hour of downtime at approximately 9 AM CDT, during which openstates.org may be
+            unavailable.<br>
             Once launched, this page will redirect to that new application at
             <a href="https://pluralpolicy.com">pluralpolicy.com</a>.
             You are invited to try out our new tools, and also you will still be able to access

--- a/templates/public/views/home.html
+++ b/templates/public/views/home.html
@@ -7,7 +7,6 @@
 {% block description %}Follow politics in your state legislature, Congress and more. Find your legislators, browse bills and track how legislators have voted.{% endblock %}
 
 {% block scripts %}
-    <script src="{% static "bundles/fyl.js" %}"></script>
     <link rel="canonical" href="https://pluralpolicy.com/open" />
 {% endblock %}
 

--- a/templates/public/views/home.html
+++ b/templates/public/views/home.html
@@ -6,7 +6,7 @@
 {% block og_title %}Open States: discover politics in your state and Congress{% endblock %}
 {% block description %}Follow politics in your state legislature, Congress and more. Find your legislators, browse bills and track how legislators have voted.{% endblock %}
 
-{% block scripts %}
+{% block link %}
     <link rel="canonical" href="https://pluralpolicy.com/open" />
 {% endblock %}
 

--- a/templates/public/views/home.html
+++ b/templates/public/views/home.html
@@ -6,12 +6,17 @@
 {% block og_title %}Open States: discover politics in your state and Congress{% endblock %}
 {% block description %}Follow politics in your state legislature, Congress and more. Find your legislators, browse bills and track how legislators have voted.{% endblock %}
 
+{% block scripts %}
+    <script src="{% static "bundles/fyl.js" %}"></script>
+    <link rel="canonical" href="https://pluralpolicy.com/open" />
+{% endblock %}
+
 {% block content %}
 
 <section class="section" id="homepage-section">
     <div class="homepage-hero">
         <div style="padding: .75rem 1.25rem; border: 1px solid #ffeeba; background-color: #fff3cd; margin-bottom: 1rem;">
-            On June 30, we’re launching a new, free bill research and tracking application!
+            On June 30, we’re launching a new, free bill research and tracking application!<br>
             Heads-up, that will mean about an hour of downtime at approximately 9 AM CDT, during which openstates.org may be
             unavailable.<br>
             Once launched, this page will redirect to that new application at
@@ -19,8 +24,8 @@
             You are invited to try out our new tools, and also you will still be able to access
             your existing OpenStates.org account.
             <a href="https://blog.openstates.org/2023-june-changes/">
-                Please read more about these upcoming changes here
-            </a>.
+                Please read more about these upcoming changes here.
+            </a>
         </div>
         <h1 class="heading--large">Discover Politics In Your State and Congress</h1>
         <p class="heading--small">Track bills, review upcoming legislation, and see how your local and federal representatives are voting.</p>

--- a/templates/public/views/legislator.html
+++ b/templates/public/views/legislator.html
@@ -10,13 +10,13 @@
 {% block scripts %}
   <script src="{% static "bundles/common_components.js" %}"></script>
   <script src="{% static "bundles/district_map.js" %}"></script>
+    <link rel="canonical" href="https://pluralpolicy.com/app/person/{{person.uuid}}/" />
 {% endblock %}
 
 {% block content %}
 <section class="section">
 
     <div class="overview">
-        
         <div class="overview__header">
           <div data-hook="legislator-image" data-image="{{ person.image }}" data-person-id="{{ person.id }}" data-size="medium" data-party="{{ person.primary_party }}"> </div>
             <div>

--- a/templates/public/views/legislator.html
+++ b/templates/public/views/legislator.html
@@ -5,7 +5,7 @@
 {% block title %}{{ person.name }} - {{ state|state_name }} {{ person.current_role.title }} - Open States{% endblock %}
 {% block og_title %}{{ person.name }} - {{ state|state_name }} {{ person.current_role.title }} - Open States{% endblock %}
 {% block description %}Contact information and legislative record for {{ person.name }} in  {{ state|state_name }}.{% endblock %}
-{% block link %}<link rel="canonical" href="https://pluralpolicy.com/app/person/{{person.id}}/" />{% endblock %}
+{% block link %}<link rel="canonical" href="https://pluralpolicy.com/app/person/{{person.id|format_uuid}}/" />{% endblock %}
 {% block og_image %}https://data.openstates.org/images/small/{{ person.id }}{% endblock %}
 
 {% block scripts %}

--- a/templates/public/views/legislator.html
+++ b/templates/public/views/legislator.html
@@ -5,7 +5,7 @@
 {% block title %}{{ person.name }} - {{ state|state_name }} {{ person.current_role.title }} - Open States{% endblock %}
 {% block og_title %}{{ person.name }} - {{ state|state_name }} {{ person.current_role.title }} - Open States{% endblock %}
 {% block description %}Contact information and legislative record for {{ person.name }} in  {{ state|state_name }}.{% endblock %}
-{% block link %}<link rel="canonical" href="https://pluralpolicy.com/app/person/{{person.uuid}}/" />{% endblock %}
+{% block link %}<link rel="canonical" href="https://pluralpolicy.com/app/person/{{person.id}}/" />{% endblock %}
 {% block og_image %}https://data.openstates.org/images/small/{{ person.id }}{% endblock %}
 
 {% block scripts %}

--- a/templates/public/views/legislator.html
+++ b/templates/public/views/legislator.html
@@ -5,12 +5,12 @@
 {% block title %}{{ person.name }} - {{ state|state_name }} {{ person.current_role.title }} - Open States{% endblock %}
 {% block og_title %}{{ person.name }} - {{ state|state_name }} {{ person.current_role.title }} - Open States{% endblock %}
 {% block description %}Contact information and legislative record for {{ person.name }} in  {{ state|state_name }}.{% endblock %}
+{% block link %}<link rel="canonical" href="https://pluralpolicy.com/app/person/{{person.uuid}}/" />{% endblock %}
 {% block og_image %}https://data.openstates.org/images/small/{{ person.id }}{% endblock %}
 
 {% block scripts %}
   <script src="{% static "bundles/common_components.js" %}"></script>
   <script src="{% static "bundles/district_map.js" %}"></script>
-    <link rel="canonical" href="https://pluralpolicy.com/app/person/{{person.uuid}}/" />
 {% endblock %}
 
 {% block content %}

--- a/templates/public/views/state.html
+++ b/templates/public/views/state.html
@@ -17,6 +17,8 @@
 
     <div style="padding: .75rem 1.25rem; border: 1px solid #ffeeba; background-color: #fff3cd; margin-bottom: 1rem;">
         On June 30, we’re launching a new, free bill research and tracking application!
+        Heads-up, that will mean about an hour of downtime at approximately 9 AM CDT, during which openstates.org may be
+        unavailable.<br>
         Once launched, this page will redirect to that new application at
         <a href="https://pluralpolicy.com">pluralpolicy.com</a>.
         You are invited to try out our new tools, and also you will still be able to access

--- a/templates/public/views/state.html
+++ b/templates/public/views/state.html
@@ -16,7 +16,7 @@
     <h1 class="heading--large">{{ legislature.name }}</h1>
 
     <div style="padding: .75rem 1.25rem; border: 1px solid #ffeeba; background-color: #fff3cd; margin-bottom: 1rem;">
-        On June 30, we’re launching a new, free bill research and tracking application!
+        On June 30, we’re launching a new, free bill research and tracking application!<br>
         Heads-up, that will mean about an hour of downtime at approximately 9 AM CDT, during which openstates.org may be
         unavailable.<br>
         Once launched, this page will redirect to that new application at
@@ -24,8 +24,8 @@
         You are invited to try out our new tools, and also you will still be able to access
         your existing OpenStates.org account.
         <a href="https://blog.openstates.org/2023-june-changes/">
-            Please read more about these upcoming changes here
-        </a>.
+            Please read more about these upcoming changes here.
+        </a>
     </div>
 
     <section class="state-overview-people">


### PR DESCRIPTION
Have to do some importing to make sure that the people & bills works as expected, but I can see the right link on the home & find your legislators page