### PR TITLE
remove full backup (we have snapshots)

### DIFF
--- a/docker/cron/backup.sh
+++ b/docker/cron/backup.sh
@@ -12,6 +12,7 @@ set -e
 ####
 
 # backup everything to private archive
+# Disabled because we now rely on snapshots from RDS
 #echo "Extracting full backup..."
 #pg_dump -Fc openstatesorg > openstatesorg.pgdump
 #echo "Shipping full backup to s3"
@@ -38,6 +39,7 @@ aws s3 cp --acl public-read public.pgdump "s3://data.openstates.org/postgres/dai
 [ "$(date +%d)" -eq 1 ] && aws s3 cp --acl public-read public.pgdump "s3://data.openstates.org/postgres/monthly/$(date +%Y-%m)-public.pgdump" > /dev/null
 rm -f public.pgdump
 
+# Currently disabled because it requires different credentials
 #echo "Extracting geo backup..."
 #pg_dump -Fc geo > openstates-geo.pgdump
 #echo "Shipping full backup to s3"

--- a/docker/cron/backup.sh
+++ b/docker/cron/backup.sh
@@ -12,11 +12,11 @@ set -e
 ####
 
 # backup everything to private archive
-echo "Extracting full backup..."
-pg_dump -Fc openstatesorg > openstatesorg.pgdump
-echo "Shipping full backup to s3"
-aws s3 cp openstatesorg.pgdump "s3://openstates-backups/full-backup/$(date +%Y-%m-%d)-openstatesorg.pgdump" > /dev/null
-rm -f openstatesorg.pgdump
+#echo "Extracting full backup..."
+#pg_dump -Fc openstatesorg > openstatesorg.pgdump
+#echo "Shipping full backup to s3"
+#aws s3 cp openstatesorg.pgdump "s3://openstates-backups/full-backup/$(date +%Y-%m-%d)-openstatesorg.pgdump" > /dev/null
+#rm -f openstatesorg.pgdump
 
 # layered approach for public
 echo "Executing public schema-only backup..."
@@ -34,7 +34,8 @@ pg_dump -Fc openstatesorg --data-only \
 
 echo "Uploading public backups to s3..."
 aws s3 cp --acl public-read public.pgdump "s3://data.openstates.org/postgres/daily/$(date +%Y-%m-%d)-public.pgdump" > /dev/null
-aws s3 cp --acl public-read public.pgdump "s3://data.openstates.org/postgres/monthly/$(date +%Y-%m)-public.pgdump" > /dev/null
+# only upload monthly dump on the first of the month
+[[ $(date +%d) -eq 1 ]] && aws s3 cp --acl public-read public.pgdump "s3://data.openstates.org/postgres/monthly/$(date +%Y-%m)-public.pgdump" > /dev/null
 rm -f public.pgdump
 
 #echo "Extracting geo backup..."

--- a/docker/cron/backup.sh
+++ b/docker/cron/backup.sh
@@ -35,7 +35,7 @@ pg_dump -Fc openstatesorg --data-only \
 echo "Uploading public backups to s3..."
 aws s3 cp --acl public-read public.pgdump "s3://data.openstates.org/postgres/daily/$(date +%Y-%m-%d)-public.pgdump" > /dev/null
 # only upload monthly dump on the first of the month
-[[ $(date +%d) -eq 1 ]] && aws s3 cp --acl public-read public.pgdump "s3://data.openstates.org/postgres/monthly/$(date +%Y-%m)-public.pgdump" > /dev/null
+[ "$(date +%d)" -eq 1 ] && aws s3 cp --acl public-read public.pgdump "s3://data.openstates.org/postgres/monthly/$(date +%Y-%m)-public.pgdump" > /dev/null
 rm -f public.pgdump
 
 #echo "Extracting geo backup..."


### PR DESCRIPTION
Simple: Disable the full backup step in our backup script. Since we have automatic snapshots in RDS, this step is just taking up space and time.