### PR TITLE
DB settings: set application_name for better performance monitoring

### DIFF
--- a/web/settings.py
+++ b/web/settings.py
@@ -100,6 +100,10 @@ DATABASE_URL = os.environ.get(
     "DATABASE_URL", "postgis://openstates:openstates@db:5432/openstatesorg"
 )
 DATABASES = {"default": dj_database_url.parse(DATABASE_URL)}
+if "OPTIONS" not in DATABASES:
+    DATABASES["default"]["OPTIONS"] = {"application_name": "openstates_django"}
+else:
+    DATABASES["default"]["OPTIONS"]["application_name"] = "openstates_django"
 CONN_MAX_AGE = 60
 
 if "CACHE_URL" in os.environ:


### PR DESCRIPTION
This makes AWS DB performance monitoring segmented by application for better understanding where load is coming from.