### PR TITLE
Legislators: redirect legislator page to Plural legislator page

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ which by default will run in docker.
 * Follow instructions for [working on openstates.org](https://docs.openstates.org/contributing/openstates-org/)
   from the docs.
 * Quirks I ran into:
+    * 2025: hit error `ERR_OSSL_EVP_UNSUPPORTED` when running `npm run build` so fixed by running `export NODE_OPTIONS=--openssl-legacy-provider`
     * `npm run start` did not actually make JS/CSS available when I hit the app at `localhost:8000`. Instead I
       ran `npm run build` and then rebuilt the docker containers with `docker compose build`, finally started them
       again.

--- a/ansible/inventory/host_vars/openstates.org.yml
+++ b/ansible/inventory/host_vars/openstates.org.yml
@@ -14,8 +14,8 @@ django_environment:
     NEW_RELIC_APP_NAME: "openstates.org"
 
 # postgres
-pg_password: "{{ lookup('aws_ssm', '/bobsled/backups/PGPASSWORD') }}"
-pg_host: "{{ lookup('aws_ssm', '/bobsled/backups/PGHOST') }}"
-pg_user: "{{ lookup('aws_ssm', '/bobsled/backups/PGUSER') }}"
+pg_password: "{{ lookup('aws_ssm', '/passwords/osorg_db_password') }}"
+pg_host: "openstates.cn70ucbuuwc7.us-east-1.rds.amazonaws.com"
+pg_user: os_django
 pg_port: 5432
 pg_database: openstatesorg

--- a/ansible/openstates/tasks/main.yml
+++ b/ansible/openstates/tasks/main.yml
@@ -169,7 +169,7 @@
 
   become_user: "openstates"
 - name: install packages via poetry
-  command: python3.9 -m poetry install # --deploy
+  command: python3.9 -m poetry install --no-root # --deploy
   changed_when: false
   args:
     chdir: /home/openstates/src/openstates.org


### PR DESCRIPTION
We have had a canonical link header on these pages for two years indicating that the correct page is now the Plural app's person page. Finally getting around to doing a hard redirect here.

We're seeing a lot of zombie bot traffic hitting these old person pages, driving a lot of DB load on querying person votes specifically. Hoping this takes a bite out of that.