### PR TITLE
Stop using deprecated datetime.utcnow() across the repo

### DIFF
--- a/bulk/management/commands/bulk_export.py
+++ b/bulk/management/commands/bulk_export.py
@@ -143,7 +143,7 @@ def export_session_csv(state, session):
     random = _str_uuid()
     filename = f"/tmp/{state}_{session}_csv_{random}.zip"
     zf = zipfile.ZipFile(filename, "w")
-    ts = datetime.datetime.utcnow()
+    ts = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
     zf.writestr(
         "README",
         f"""Open States Data Export
@@ -248,7 +248,7 @@ def export_session_json(state, session):
     random = _str_uuid()
     filename = f"/tmp/{state}_{session}_json_{random}.zip"
     zf = zipfile.ZipFile(filename, "w")
-    ts = datetime.datetime.utcnow()
+    ts = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
     zf.writestr(
         "README",
         f"""Open States Data Export

--- a/profiles/management/commands/process_subscriptions.py
+++ b/profiles/management/commands/process_subscriptions.py
@@ -117,7 +117,7 @@ def send_subscription_email(user, query_updates, bill_updates, dry_run=False):
 
     update_count = len(query_updates) + len(bill_updates)
     updates = "update" if update_count == 1 else "updates"
-    today = datetime.datetime.utcnow().strftime("%d %b %Y")
+    today = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None).strftime("%d %b %Y")
     if user.profile.subscription_frequency == DAILY:
         subject = f"Open States Daily Alert - {today}: {update_count} {updates}"
     else:

--- a/profiles/utils.py
+++ b/profiles/utils.py
@@ -1,6 +1,5 @@
 import datetime
-import pytz
 
 
 def utcnow():
-    return pytz.utc.localize(datetime.datetime.utcnow())
+    return datetime.datetime.now(datetime.timezone.utc)

--- a/profiles/verifier.py
+++ b/profiles/verifier.py
@@ -84,7 +84,7 @@ def verify(key, zone):
         )
 
     # enforce daily quota
-    quota_range = datetime.datetime.utcnow().strftime("%Y%m%d")
+    quota_range = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None).strftime("%Y%m%d")
 
     if backend.get_and_inc_quota_value(key, zone, quota_range) > limit.daily_requests:
         raise QuotaError(f"quota exceeded: {limit.daily_requests}/day")


### PR DESCRIPTION
`datetime.utcnow()` is deprecated in 3.12. Swapped the five call sites:

- `profiles/utils.py:utcnow` returns tz-aware (`pytz` wrap was already aiming for that)
- bulk export and the two verifier/process_subscriptions strftime callers keep the naive shape via `.replace(tzinfo=None)` so the printed timestamps don't suddenly grow `+00:00`